### PR TITLE
chore: add dependabot config for @jspm/generator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: "@jspm/generator"


### PR DESCRIPTION
Targets just the `@jspm/generator` dependency for now.
