### PR TITLE
chore: Update jspm-cli to use resolutions flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@vercel/ncc": "^0.38.1",
         "chomp": "^0.2.17",
         "cjs-module-lexer": "^1.2.3",
-        "jspm": "^3.1.0"
+        "jspm": "^3.1.2"
       },
       "engines": {
         "vscode": "^1.77.0"
@@ -3481,12 +3481,12 @@
       }
     },
     "node_modules/jspm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jspm/-/jspm-3.1.0.tgz",
-      "integrity": "sha512-5erLAhhYH6OQr7gGKyq16QHQKj/pU8z2/1aTs+h/6B760ZM1O/WTEmnXXn+JuKPV6fYml0+4xRmpUs3b2o1GTQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jspm/-/jspm-3.1.2.tgz",
+      "integrity": "sha512-2m5QwjMltpdMNBd5A4PCmRI85fIuq0AuMamJqjzRFOnd40BjXKhL8N0bTsaOedMGPSO7uGkDyoLExCJzoPBo3Q==",
       "dev": true,
       "dependencies": {
-        "@jspm/generator": "^1.1.10",
+        "@jspm/generator": "^1.1.12",
         "cac": "^6.7.14",
         "ora": "^6.3.0",
         "picocolors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "@vercel/ncc": "^0.38.1",
     "chomp": "^0.2.17",
     "cjs-module-lexer": "^1.2.3",
-    "jspm": "^3.1.0"
+    "jspm": "^3.1.2"
   }
 }


### PR DESCRIPTION
fixes #17 

With the current `generator.install()` happening in the `jspm build` command we need to run the build by passing custom resolutions. And the flag is available in the latest version of the `cli`
https://github.com/jspm/jspm-cli/releases/tag/3.1.2